### PR TITLE
[Fix]カート内がからの時

### DIFF
--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -54,9 +54,12 @@
        <%= form.submit '買い物を続ける', class: "btn btn-primary" %>
       <% end %>
     </div>
+
     <div class="col-lg-6">
-      <%= form_with url: new_order_path, method: :get, local: true do |form| %>
-        <%= form.submit '情報入力に進む', class: "btn btn-success" %>
+      <% if @cart_items.present? %>
+        <%= form_with url: new_order_path, method: :get, local: true do |form| %>
+          <%= form.submit '情報入力に進む', class: "btn btn-success" %>
+        <% end %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
カート内が空の時、情報入力に進むボタンの表示がされないように修正しました。
確認お願いします。